### PR TITLE
fix(namespace): project call fails if non-existing

### DIFF
--- a/ocviapy/__init__.py
+++ b/ocviapy/__init__.py
@@ -814,7 +814,10 @@ def get_all_namespaces(label=None):
 def get_current_namespace():
     """Get current namespace/project"""
     if not on_k8s():
-        return oc(shlex.split("project -q")).strip()
+        namespace = oc(shlex.split("project -q"), _ignore_errors=True)
+        if not namespace:
+            return None
+        return namespace.strip()
 
     context_name = oc(shlex.split("config current-context")).strip()
     if not context_name:


### PR DESCRIPTION
The `oc project` command fails for unknown (or forbidden) project/namespace. Rather ignore the error and return `None` instead.