### PR TITLE
Add exceptions for dealing with image errors on pods

### DIFF
--- a/ocviapy/__init__.py
+++ b/ocviapy/__init__.py
@@ -438,6 +438,14 @@ def _check_status_for_restype(restype, json_data):
     elif restype == "pod":
         if status.get("phase").lower() == "running":
             return True
+        # if pod is in imagepullbackoff raise an exception
+        elif status.get("phase").lower() == "pending":
+            if status.get("containerStatuses"):
+                for container in status.get("containerStatuses"):
+                    if container.get("state", {}).get("waiting", {}).get("reason") == "ImagePullBackOff":
+                        raise StatusError(f"pod {json_data['metadata']['name']} is in ImagePullBackOff state")
+                    if container.get("state", {}).get("waiting", {}).get("reason") == "ErrImagePull":
+                        raise StatusError(f"pod {json_data['metadata']['name']} is in ErrImagePull state")
 
     elif restype in ("clowdenvironment", "clowdapp"):
         return _check_status_condition(
@@ -699,7 +707,10 @@ class ResourceWaiter:
                     timeout=timeout,
                 )
             return True
-        except (StatusError, ErrorReturnCode) as err:
+        except (StatusError) as err:
+            log.error("[%s] hit status error waiting for resource to be ready: %s", self.key, str(err))
+            raise err
+        except (ErrorReturnCode) as err:
             log.error("[%s] hit error waiting for resource to be ready: %s", self.key, str(err))
             if reraise:
                 raise


### PR DESCRIPTION
This patch adds exceptions for image pull backoff and image errors. But, at the time of this writing, I haven't adequately confirmed that it works. 