### PR TITLE
Remove 'import pkg_resources' from gh pipeline

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,6 @@ jobs:
         run: |
           python -m pip install pip --upgrade
           pip install -e .
-          python -c "import pkg_resources; print(pkg_resources.get_distribution('ocviapy').version)"
           python -c "from ocviapy import get_associated_pods, get_routes, get_json"
 
   package:


### PR DESCRIPTION
The pipelines are failing on this import and it doesn't seem to be a necessary component of the tests